### PR TITLE
Updated action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -74,7 +74,7 @@ runs:
 
       - name: Formating the results  
         run: | 
-          jq --arg repoLink "${{ github.server_url }}/${{ github.repository }}" --arg branch "${{ github.head_ref }}" '. += [{"details": {"repo": $repoLink, "branch": $branch}}]' results/results_json.json > temp.json && mv temp.json results.json
+          jq --arg repoLink "${{ github.server_url }}/${{ github.repository }}" --arg branch "${{ github.ref == 'refs/heads/main' && 'main' || github.head_ref }}" '. += [{"details": {"repo": $repoLink, "branch": $branch}}]' results/results_json.json > temp.json && mv temp.json results.json
         shell: bash
 
 


### PR DESCRIPTION
Changed jq formatting to set the branch variable value from github.head_ref to github.ref == 'refs/heads/main' && 'main' || github.head_ref. This ensures that when sending results from the main branch, it will be correctly labeled as 'main', while on other branches, the branch name will be taken from github.head_ref