### PR TITLE
chore: update CLI version in action workflow

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -62,7 +62,7 @@ runs:
         fi
 
         echo "Downloading AccuKnox ASPM Scanner..."
-        curl -L https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.4/accuknox-aspm-scanner -o accuknox-aspm-scanner
+        curl -L https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.8/accuknox-aspm-scanner -o accuknox-aspm-scanner
         chmod +x accuknox-aspm-scanner
 
         CMD_ARGS=""


### PR DESCRIPTION
The updated CLI now correctly enforces failure behaviour across all scan types. 
This commit updates the action configuration to use the new CLI version, so workflow runs fail when any scan reports a failure.