### PR TITLE
feat: latest-tag workflow

### DIFF
--- a/.github/workflows/latest-tag.yml
+++ b/.github/workflows/latest-tag.yml
@@ -1,0 +1,22 @@
+name: Update floating latest tag
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update "latest" tag
+        uses: EndBug/latest-tag@v1.6.2
+        with:
+          ref: latest
+          force-branch: false
+          description: "Auto-tag latest after ${{ github.event.release.tag_name }}"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@main
 
       - name: Run IaC scan
-        uses: accuknox/iac-scan-action@v1.0.1
+        uses: accuknox/iac-scan-action@latest
         with:
           directory: "."                            # Optional: Directory to scan
           compact: true                             # Optional: Minimise output


### PR DESCRIPTION
Keeps a floating 'latest' tag updated whenever a release is made